### PR TITLE
Add Kubernetes v1.16 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,11 @@ A full example with VPC resources in [example](example).
 
 Authentication: RBAC only
 
-Networking: calico or flannel
+Networking: weave
 
-Kops version: 1.10.0
+Kops version: 1.16.0-beta.1
 
 Supported Kubernetes versions:
-  - 1.9.8
-  - 1.10.9
-  - 1.10.11
   - 1.11.6
-  - 1.12.9 _(recommended)_
+  - 1.12.9
+  - 1.16.6 _(recommended)_

--- a/README.md
+++ b/README.md
@@ -43,7 +43,5 @@ Networking: weave
 
 Kops version: 1.16.0-beta.1
 
-Supported Kubernetes versions:
-  - 1.11.6
-  - 1.12.9
+Supported Kubernetes versions (pre v1.16 isn't supported due to hashing changes in the `kops` init scripts):
   - 1.16.6 _(recommended)_

--- a/module/locals.tf
+++ b/module/locals.tf
@@ -45,32 +45,6 @@ locals {
       storage_backend = "etcd3"
       etcd_version    = "3.3.10"
     }
-    "1.12.9" = {
-      kubelet_hash    = "e914b17532c411cb7c0cc472131b61935fb66b31"
-      kubectl_hash    = "aa3e93897a6999d6c7dedbc41793c90d41eeb000"
-      cni_hash        = "52e9d2de8a5f927307d9397308735658ee44ab8d"
-      cni_file_name   = "cni-plugins-amd64-v0.7.5.tgz"
-      utils_hash      = "ad4085c05ff02c241a38ff0033d76c699316f298"
-      protokube_hash  = "175d2d9df2b9e317a40749a6d735577546a3c38d"
-      docker_version  = "18.06.3"
-      ami_name        = "k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-14"
-      ami_owner       = "383156758163"
-      storage_backend = "etcd3"
-      etcd_version    = "3.2.24"
-    }
-    "1.11.6" = {
-      kubelet_hash    = "a006b4680640e5c88742e22b904623a77257f416"
-      kubectl_hash    = "c3f7fbab5ba39e3ec20b32f0e7bcad6cc0704792"
-      cni_hash        = "d595d3ded6499a64e8dac02466e2f5f2ce257c9f"
-      cni_file_name   = "cni-plugins-amd64-v0.6.0.tgz"
-      utils_hash      = "b16b5367e05bad082f416f786c7f8813f7794630"
-      protokube_hash  = "725c2de47755544a9aa349e27ed9900d195f0ceb"
-      docker_version  = "18.06.1"
-      ami_name        = "k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17"
-      ami_owner       = "383156758163"
-      storage_backend = "etcd3"
-      etcd_version    = "3.1.12"
-    }
   }
 }
 

--- a/module/locals.tf
+++ b/module/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  # Currently support kops version
-  supported_kops_version = "1.12.1"
+  # Currently supported kops version
+  supported_kops_version = "1.16.0-beta.1"
 
   # Removes the last character of the FQDN if it is '.'
   cluster_fqdn = replace(var.cluster_fqdn, "/\\.$/", "")
@@ -32,6 +32,19 @@ locals {
   # Easiest way to get new hashes is to create a dummy cluster using kops and
   # check user data.
   k8s_versions = {
+    "1.16.6" = {
+      kubelet_hash    = "47b99b6b9c4654a3fd5e3f093763429f8a6007f788bd7394bd0b85cb7ae4b2d0"
+      kubectl_hash    = "05aae29c6e96fc07db195878263d3b625b623b9f16f87851e4a8ed8d234bcc2d"
+      cni_hash        = "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64"
+      cni_file_name   = "cni-plugins-amd64-v0.7.5.tgz"
+      utils_hash      = "fef545b247951287c4509dcb606b4370f4241bfa94a6c0181c83eac2295856c7"
+      protokube_hash  = "9453692c9de143353b1ae38e2dcb22524e131ddcdcf1b373be94876c87a437d1"
+      docker_version  = "18.09.9"
+      ami_name        = "k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17"
+      ami_owner       = "383156758163"
+      storage_backend = "etcd3"
+      etcd_version    = "3.3.10"
+    }
     "1.12.9" = {
       kubelet_hash    = "e914b17532c411cb7c0cc472131b61935fb66b31"
       kubectl_hash    = "aa3e93897a6999d6c7dedbc41793c90d41eeb000"
@@ -57,45 +70,6 @@ locals {
       ami_owner       = "383156758163"
       storage_backend = "etcd3"
       etcd_version    = "3.1.12"
-    }
-    "1.10.11" = {
-      kubelet_hash    = "dbe06f92f4d1878482af0188070c6c0bca5d5e65"
-      kubectl_hash    = "9ee2f78491cbf8dc76d644c23cfc8c955c34d55d"
-      cni_hash        = "d595d3ded6499a64e8dac02466e2f5f2ce257c9f"
-      cni_file_name   = "cni-plugins-amd64-v0.6.0.tgz"
-      utils_hash      = "1903d30f87488f6e3550918283ff8aa1c5553471"
-      protokube_hash  = "139d69230bb029a419ca8e5a9be2f406d8e685c4"
-      docker_version  = "17.09.0"
-      ami_name        = "k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-08-17"
-      ami_owner       = "383156758163"
-      storage_backend = "etcd3"
-      etcd_version    = "3.1.12"
-    }
-    "1.10.9" = {
-      kubelet_hash    = "aadc25f7a7497d91419b168e4cb06e16755e8916"
-      kubectl_hash    = "bf3914630fe45b4f9ec1bc5e56f10fb30047f958"
-      cni_hash        = "d595d3ded6499a64e8dac02466e2f5f2ce257c9f"
-      cni_file_name   = "cni-plugins-amd64-v0.6.0.tgz"
-      utils_hash      = "1903d30f87488f6e3550918283ff8aa1c5553471"
-      protokube_hash  = "139d69230bb029a419ca8e5a9be2f406d8e685c4"
-      docker_version  = "17.09.0"
-      ami_name        = "k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-08-17"
-      ami_owner       = "383156758163"
-      storage_backend = "etcd3"
-      etcd_version    = "3.1.12"
-    }
-    "1.9.8" = {
-      kubelet_hash    = "6468397888494efe4a32e6bd96700ba6a86e635a"
-      kubectl_hash    = "9a3537a7d95f1beec55e2fae082c364f6b91fdc0"
-      cni_hash        = "d595d3ded6499a64e8dac02466e2f5f2ce257c9f"
-      cni_file_name   = "cni-plugins-amd64-v0.6.0.tgz"
-      utils_hash      = "72fac6679084d1f929d0abbd8a9ff9337273504b"
-      protokube_hash  = "527db0b5fd4b635e6cb2ca22bfec813a048855a7"
-      docker_version  = "1.13.1"
-      ami_name        = "k8s-1.9-debian-jessie-amd64-hvm-ebs-2018-05-27"
-      ami_owner       = "383156758163"
-      storage_backend = "etcd2"
-      etcd_version    = "2.2.1"
     }
   }
 }

--- a/module/masters_user_data.tf
+++ b/module/masters_user_data.tf
@@ -4,6 +4,7 @@ data "template_file" "master_user_data_1" {
 
   vars = {
     kops_version = local.supported_kops_version
+    aws_region   = data.aws_region.current.name
   }
 }
 

--- a/module/nodes.tf
+++ b/module/nodes.tf
@@ -40,6 +40,12 @@ resource "aws_autoscaling_group" "node" {
   }
 
   tag {
+    key                 = "kops.k8s.io/instancegroup"
+    value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag {
     key                 = "k8s.io/role/node"
     value               = "1"
     propagate_at_launch = true
@@ -141,6 +147,12 @@ resource "aws_autoscaling_group" "node_spot" {
   }
 
   tag {
+    key                 = "kops.k8s.io/instancegroup"
+    value               = "nodes-spot"
+    propagate_at_launch = true
+  }
+
+  tag {
     key                 = "k8s.io/role/node"
     value               = "1"
     propagate_at_launch = true
@@ -224,6 +236,12 @@ resource "aws_autoscaling_group" "nodes_additional" {
 
   tag {
     key                 = "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"
+    value               = var.additional_instance_groups[count.index].name
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kops.k8s.io/instancegroup"
     value               = var.additional_instance_groups[count.index].name
     propagate_at_launch = true
   }

--- a/module/nodes_user_data.tf
+++ b/module/nodes_user_data.tf
@@ -3,6 +3,7 @@ data "template_file" "node_user_data_1" {
 
   vars = {
     kops_version = local.supported_kops_version
+    aws_region   = data.aws_region.current.name
   }
 }
 

--- a/module/security_group_rules.tf
+++ b/module/security_group_rules.tf
@@ -71,4 +71,3 @@ resource "aws_security_group_rule" "node_to_master_udp_1-65535" {
   to_port                  = 65535
   protocol                 = "udp"
 }
-

--- a/module/user_data/01_nodeup_url.sh.tpl
+++ b/module/user_data/01_nodeup_url.sh.tpl
@@ -20,8 +20,5 @@ set -o pipefail
 NODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/${kops_version}/linux/amd64/nodeup
 NODEUP_HASH=
 
-
-
-
-
+export AWS_REGION=${aws_region}
 #

--- a/module/user_data/02_download_nodeup.sh
+++ b/module/user_data/02_download_nodeup.sh
@@ -8,48 +8,39 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
-# Retry a download until we get it. Takes a hash and a set of URLs.
-#
-# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-# $2+ are the URLs to download.
+# Retry a download until we get it. args: name, sha, url1, url2...
 download-or-bust() {
-  local -r hash="$1"
-  shift 1
+  local -r file="$1"
+  local -r hash="$2"
+  shift 2
 
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      local file="${url##*/}"
-
-      if [[ -e "${file}" ]]; then
-        echo "== File exists for ${url} =="
-
-      # CoreOS runs this script in a container without which (but has curl)
-      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-      # So we default to wget unless we see curl
-      elif [[ $(curl --version) ]]; then
-        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-          echo "== Failed to curl ${url}. Retrying. =="
-          break
+      commands=(
+        "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "Attempting download with: ${cmd} {url}"
+        if ! (${cmd} "${url}"); then
+          echo "== Download failed with ${cmd} =="
+          continue
         fi
-      else
-        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-          echo "== Failed to wget ${url}. Retrying. =="
-          break
-        fi
-      fi
-
-      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-        echo "== Hash validation of ${url} failed. Retrying. =="
-        rm -f "${file}"
-      else
-        if [[ -n "${hash}" ]]; then
-          echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+          echo "== Hash validation of ${url} failed. Retrying. =="
+          rm -f "${file}"
         else
-          echo "== Downloaded ${url} =="
+          if [[ -n "${hash}" ]]; then
+            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          else
+            echo "== Downloaded ${url} =="
+          fi
+          return
         fi
-        return
-      fi
+      done
     done
 
     echo "All downloads failed; sleeping before retrying"
@@ -62,9 +53,9 @@ validate-hash() {
   local -r expected="$2"
   local actual
 
-  actual=$(sha1sum ${file} | awk '{ print $1 }') || true
+  actual=$(sha256sum ${file} | awk '{ print $1 }') || true
   if [[ "${actual}" != "${expected}" ]]; then
-    echo "== ${file} corrupted, sha1 ${actual} doesn't match expected ${expected} =="
+    echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
     return 1
   fi
 }
@@ -78,18 +69,17 @@ function try-download-release() {
   # optimization.
 
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-  local -r nodeup_filename="${nodeup_urls[0]##*/}"
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"
   else
   # TODO: Remove?
-    echo "Downloading sha1 (not found in env)"
-    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+    echo "Downloading sha256 (not found in env)"
+    download-or-bust nodeup.sha256 "" "${nodeup_urls[@]/%/.sha256}"
+    local -r nodeup_hash=$(cat nodeup.sha256)
   fi
 
   echo "Downloading nodeup (${nodeup_urls[@]})"
-  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+  download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
   chmod +x nodeup
 }

--- a/module/user_data/03_master_cluster_spec.sh.tpl
+++ b/module/user_data/03_master_cluster_spec.sh.tpl
@@ -89,7 +89,6 @@ kubeScheduler:
     leaderElect: true
   logLevel: 2
 kubelet:
-  allowPrivileged: true
   anonymousAuth: false
   cgroupRoot: /
   cloudProvider: aws
@@ -97,8 +96,6 @@ kubelet:
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-  featureGates:
-    ExperimentalCriticalPodAnnotation: "true"
   hostnameOverride: '@aws'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
@@ -107,7 +104,6 @@ kubelet:
   podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
   podManifestPath: /etc/kubernetes/manifests
 masterKubelet:
-  allowPrivileged: true
   anonymousAuth: false
   cgroupRoot: /
   cloudProvider: aws
@@ -115,8 +111,6 @@ masterKubelet:
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-  featureGates:
-    ExperimentalCriticalPodAnnotation: "true"
   hostnameOverride: '@aws'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2

--- a/module/user_data/03_node_cluster_spec.sh.tpl
+++ b/module/user_data/03_node_cluster_spec.sh.tpl
@@ -20,7 +20,6 @@ kubeProxy:
   image: k8s.gcr.io/kube-proxy:v${kubernetes_version}
   logLevel: 2
 kubelet:
-  allowPrivileged: true
   anonymousAuth: false
   cgroupRoot: /
   cloudProvider: aws
@@ -28,8 +27,6 @@ kubelet:
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-  featureGates:
-    ExperimentalCriticalPodAnnotation: "true"
   hostnameOverride: '@aws'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -158,7 +158,7 @@ variable "spot_asg_max" {
 # Kubernetes version tag to use
 variable "kubernetes_version" {
   type    = string
-  default = "1.12.9"
+  default = "1.16.6"
 }
 
 # List of private subnet IDs. Pass 1 per AZ or if left blank then public subnets will be used

--- a/module/versions.tf
+++ b/module/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
 }

--- a/module/vpc_resources.tf
+++ b/module/vpc_resources.tf
@@ -35,4 +35,3 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.public.id
   subnet_id      = element(aws_subnet.public.*.id, count.index)
 }
-


### PR DESCRIPTION
Unfortunately, we have to remove pre-v1.16 support as part of this, due to the shift to SHA256 hashes (the download script has changed).

Use v1.12.9 (or earlier) for pre-v1.16 support.